### PR TITLE
Improve email text

### DIFF
--- a/app/src/components/AppConnection/ServiceDataForm/ServiceForm.js
+++ b/app/src/components/AppConnection/ServiceDataForm/ServiceForm.js
@@ -23,6 +23,7 @@ class ServiceForm extends Component {
       mesgAddress: currentApp.appAddress,
       eventSignature,
       instanceHash: service.instanceHash,
+      serviceLabel: service.label,
       data: this.state
     })
 

--- a/app/src/utils/helper.js
+++ b/app/src/utils/helper.js
@@ -6,3 +6,19 @@ export const IsValidJSONString = str => {
   }
   return true
 }
+
+export const emailTemp = (appName, { name, text, serviceLabel, abiName }) => {
+  const html =
+    'module.export = value => `<!DOCTYPE html><html><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1.0"><link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;600;700&family=Roboto&display=swap" rel="stylesheet"><title>Document</title><style media="screen">body {font-family: "Open Sans", sans-serif;height: 100%; margin: 0; padding: 0;}</style></head><body><div style="min-width: 350px;max-width: 350px;min-height: 420px;border: 1.5px solid;border-radius: 15px;padding: 20px 20px 10px 25px;"><h2>Email Notification</h2><div>' +
+    text +
+    '</div><div style="margin: 20px 0;height: 2px;background: rgba(0,0,0,.1);"></div><h3>Information</h3><div style="max-width: 100%;"><div style=" margin: 15px 0;"><span><strong>From: </strong>' +
+    appName +
+    '</span></div><div style=" margin: 15px 0;"><span><strong>Application: </strong>' +
+    name +
+    '</span></div><div style=" margin: 15px 0;"><span><strong>Event: </strong>' +
+    abiName +
+    '</span></div><div style=" margin: 15px 0;"><span><strong>Task: </strong>' +
+    serviceLabel +
+    '</span></div><div style=" margin: 15px 0;"><a href="https://rinkeby.etherscan.io/tx/${value.transactionHash}" target="_blank">Transaction hash link</a></div></div><div style="margin-top: 5rem;"><footer style="margin:10px 0;color: rgba(0,0,0,.5);font-size: .8em;text-align: center;">COPYRIGHT © MESG, All rights Reserved</footer></div</div></body</html>`'
+  return html.toString().trim()
+}

--- a/app/src/utils/template/email.js
+++ b/app/src/utils/template/email.js
@@ -1,9 +1,9 @@
 import { process } from '@liteflow/compiler'
+import { emailTemp } from '../helper'
 
-// eslint-disable-next-line no-template-curly-in-string
-const code = text => 'module.export = value => `' + text + ', Transaction hash link is https://rinkeby.etherscan.io/tx/${value.transactionHash}`'
+export default async ({ name, appAddress, eventAbi, mesgAddress, eventSignature, instanceHash, data, serviceLabel }) => {
+  const mailTemp = emailTemp('Aragon', { name, text: data.text, serviceLabel, abiName: eventAbi.name })
 
-export default async ({ name, appAddress, eventAbi, mesgAddress, eventSignature, instanceHash, data }) => {
   const temp = `
 name: ${name}-${mesgAddress}-${eventAbi.name}
 steps:
@@ -31,7 +31,8 @@ steps:
   instanceHash: ${process.env.JS_HASH}
   taskKey: execute
   inputs:
-    code: ${code(data.text)}
+    code: >
+      ${mailTemp}
     inputs:
       decodedData: {key: decodedData}
       address: {key: address}

--- a/app/src/utils/template/email.js
+++ b/app/src/utils/template/email.js
@@ -1,5 +1,8 @@
 import { process } from '@liteflow/compiler'
 
+// eslint-disable-next-line no-template-curly-in-string
+const code = text => 'module.export = value => `' + text + ', Transaction hash link is https://rinkeby.etherscan.io/tx/${value.transactionHash}`'
+
 export default async ({ name, appAddress, eventAbi, mesgAddress, eventSignature, instanceHash, data }) => {
   const temp = `
 name: ${name}-${mesgAddress}-${eventAbi.name}
@@ -25,14 +28,31 @@ steps:
     blockHash: {key: blockHash}
     blockNumber: {key: blockNumber}
 - type: task
+  instanceHash: ${process.env.JS_HASH}
+  taskKey: execute
+  inputs:
+    code: ${code(data.text)}
+    inputs:
+      decodedData: {key: decodedData}
+      address: {key: address}
+      eventSignature: {key: eventSignature}
+      data: {key: data}
+      topics: {key: topics}
+      logIndex: {key: logIndex}
+      transactionHash: {key: transactionHash}
+      transactionIndex: {key: transactionIndex}
+      blockHash: {key: blockHash}
+      blockNumber: {key: blockNumber}
+- type: task
   instanceHash: ${instanceHash}
   taskKey: send
   inputs:
     from: 'notification@mesg.com'
     to: ${data.to}
     subject: ${data.subject}
-    text: ${data.text}
-  `
+    text: {key: result}
+  `.trim()
+
   const compiler = await process(Buffer.from(temp))
   return compiler
 }

--- a/app/src/utils/template/email.js
+++ b/app/src/utils/template/email.js
@@ -50,7 +50,7 @@ steps:
     from: 'notification@mesg.com'
     to: ${data.to}
     subject: ${data.subject}
-    text: {key: result}
+    html: {key: result}
   `.trim()
 
   const compiler = await process(Buffer.from(temp))


### PR DESCRIPTION
- Add `js-function` service
- Add email style with HTML 

This pull request isn't published because of `js-function` doesn't deploy and doesn't have instanceHash of `js-function`

code compiler: https://ipfs.app.mesg.com/ipfs/QmZCtWRezTwpzTCbuJDhvCPhxVUKYPK86rLobQ4btkXBUs

email style example: 
<img width="437" alt="Screen Shot 2563-05-12 at 14 48 29" src="https://user-images.githubusercontent.com/16553272/81676398-fa543e00-9479-11ea-86a6-fd89cd6a24d4.png">

close https://github.com/mesg-foundation/aragon/issues/16.
close https://github.com/mesg-foundation/aragon/issues/15.
